### PR TITLE
Fix home sidebar links.

### DIFF
--- a/_includes/sidebar-home.html
+++ b/_includes/sidebar-home.html
@@ -14,8 +14,8 @@
     <ul>
         <li><a href="http://board.s9y.org/">User support forums</a></li>
         <li><a href="https://github.com/s9y/Serendipity/issues">GitHub bug tracker</a></li>
-        <li><a href="/docs/contributing/index.html#security-reports-exploits">Report security issues</a></li>
-        <li><a href="/docs/contributing/index.html#we-need-your-help">How you can help</a></li>
-        <li><a href="/docs/users/hosting.html#commercial-support">Get commercial support</a></li>
+        <li><a href="/docs/contributing/index.html#docs-security-reports-exploits">Report security issues</a></li>
+        <li><a href="/docs/contributing/index.html#docs-we-need-your-help">How you can help</a></li>
+        <li><a href="/docs/users/hosting.html#docs-commercial-support">Get commercial support</a></li>
     </ul>
 </section>


### PR DESCRIPTION
IDs for headings have a "docs-" prepended, so e.g.
"Commercial support"  on /docs/users/hosting.html
has an ID of "docs-commercial-support", not
"commercial-support".

Change sidebar links accordingly.

Signed-off-by: Thomas Hochstein thh@inter.net
