### PR TITLE
Change TOC structure of developer documentation.

### DIFF
--- a/_includes/sidebar-docs.html
+++ b/_includes/sidebar-docs.html
@@ -14,7 +14,7 @@
         <li><a href="/docs/developers/index.html">Developers</a>
             <ul>
                 <li><a href="/docs/developers/code-primer.html">Code Primer</a></li>
-                <li><a href="/docs/developers/index.html">Developing</a></li>
+                <li><a href="/docs/developers/developing.html">Developing</a></li>
             </ul>
         </li>
         <li><a href="/docs/contributing/index.html">Contributing</a>

--- a/docs/developers/developing.md
+++ b/docs/developers/developing.md
@@ -1,0 +1,16 @@
+---
+layout: docs
+title: Technical Documentation
+---
+
+## Technical Documentation
+
+*  [Database](database.html)
+*  [Important API Functions](functions.html)
+*  [Plugin API](plugin-api.html)
+*  [Themes and Smarty Templating](themes.html)
+*  [Conditional Get for RSS Feeds](conditional-get.html)
+*  [Internationalization](internationalization.html)
+*  [Lighttpd](lighttpd.html)
+*  [Editing entries.tpl](entries_tpl.html)
+*  [Microsoft IIS Setup](iis-setup.html)

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,16 +1,11 @@
 ---
 layout: docs
-title: Technical Documentation
+title: Developers
 ---
 
-## Technical Documentation
+## Users
 
-*  [Database](database.html)
-*  [Important API Functions](functions.html)
-*  [Plugin API](plugin-api.html)
-*  [Themes and Smarty Templating](themes.html)
-*  [Conditional Get for RSS Feeds](conditional-get.html)
-*  [Internationalization](internationalization.html)
-*  [Lighttpd](lighttpd.html)
-*  [Editing entries.tpl](entries_tpl.html)
-*  [Microsoft IIS Setup](iis-setup.html)
+This part of the documentation is aimed at developers.
+
+* [Code Primer](/docs/developers/code-primer.html)
+* [Technical Documentation](/docs/developers/developing.html)


### PR DESCRIPTION
"Developers" and "Developers -> Developing" link to the same page.

Add a portal page for "Developers" instead, very much like the page for "Users".

Signed-off-by: Thomas Hochstein <thh@inter.net>