### PR TITLE
Fix TOC generation for camp page.

### DIFF
--- a/camp.md
+++ b/camp.md
@@ -10,7 +10,7 @@ title: s9ycamp
 -   [Kosten](#docs-kosten)
 -   [Verpflegung](#docs-verpflegung)
 -   [Verbindlichkeit](#docs-verbindlichkeit)
-    {:toc}
+{:toc}
 
 ### Allgemeines
 

--- a/camp.md
+++ b/camp.md
@@ -5,7 +5,11 @@ title: s9ycamp
 
 <h2>Serendipity-Treffen 2020</h2>
 
--   TOC
+-   [Allgemeines](#docs-allgemeines)
+-   [Termin](#docs-termin)
+-   [Kosten](#docs-kosten)
+-   [Verpflegung](#docs-verpflegung)
+-   [Verbindlichkeit](#docs-verbindlichkeit)
     {:toc}
 
 ### Allgemeines


### PR DESCRIPTION
"{:toc}" may not be indented.

Add fallback TOC, too.